### PR TITLE
Prevent boost 1.72 in conda

### DIFF
--- a/conda-recipe/AimIO/meta.yaml
+++ b/conda-recipe/AimIO/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - gtest
     - n88util >=2.0
   run:
-    - boost >=1.57
+    - boost >=1.57,<=1.67
     - n88util >=2.0
 
 about:


### PR DESCRIPTION
Should fix https://github.com/Bonelab/Bonelab/issues/18.

In the future, we can update to 1.72. We will need to modify CMakeLists.txt as well.