### PR TITLE
CMake updates to improve package import/export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,5 +153,6 @@ install(EXPORT AimIOTargets
 
 option (ENABLE_TESTING "Build unit and other tests" OFF)
 if (ENABLE_TESTING)
+  enable_testing()
   add_subdirectory (tests)
 endif (ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if (WIN32)
   add_definitions (-DBOOST_ALL_NO_LIB)
 endif()
 
-include_directories (${Boost_INCLUDE_DIR})
+include_directories (${Boost_INCLUDE_DIRS})
 
 # == Create library
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ set(AIMIO_PATCH_VERSION 0)
 set(AIMIO_VERSION
   ${AIMIO_MAJOR_VERSION}.${AIMIO_MINOR_VERSION}.${AIMIO_PATCH_VERSION})
 
+# === Standard CMake options
+
+option (BUILD_SHARED_LIBS "Build shared libraries" OFF)
+
 # Ensure that CMake behaves predictably
 set (CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
 set (CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include (GenerateExportHeader)
 add_library (AimIO ${SRC})
 set_target_properties(AimIO 
   PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
     VERSION ${AIMIO_VERSION}
     SOVERSION ${AIMIO_MAJOR_VERSION}.${AIMIO_MINOR_VERSION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ endforeach()
 
 # Add all targets to the build-tree export set
 export (TARGETS AimIO
+    NAMESPACE AimIO::
     FILE "${PROJECT_BINARY_DIR}/AimIOTargets.cmake")
 
 # Export the package for use from the build-tree

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ add_custom_target (test_data
 
 # === Actual tests (single google test binary) ===
 include_directories ("${GTEST_INCLUDE_DIR}")
-include_directories (${Boost_INCLUDE_DIR})
+include_directories (${Boost_INCLUDE_DIRS})
 
 add_executable (AimIOTests
   AimIOTests.cxx)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-enable_testing()
 find_package (GTest REQUIRED)
 find_package (Boost 1.61.0 COMPONENTS filesystem system REQUIRED)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_target (test_data
 
 
 # === Actual tests (single google test binary) ===
-include_directories ("${GTEST_INCLUDE_DIR}")
+include_directories (${GTEST_INCLUDE_DIRS})
 include_directories (${Boost_INCLUDE_DIRS})
 
 add_executable (AimIOTests


### PR DESCRIPTION
This includes the following changes:

1. Add NAMESPACE to the export for the build tree
2. Use Boost\_INCLUDE\_DIRS according to current FindBoost documentation
3. Use GTEST\_INCLUDE\_DIRS according to current FindGTest documentation
4. Force POSITION\_INDEPENDENT\_CODE (i.e. even for static libraries)
5. Fix enable\_testing() by moving it to the main CMakeLists.txt
6. Default BUILD\_SHARED\_LIBS to OFF

The NAMESPACE had been omitted from the export for the build tree, though it was present for the export for the install tree. Now the namespace is consistently applied.

For both Boost and googletest, CMake currently specifies that \_INCLUDE\_DIRS (rather than \_INCLUDE\_DIR) should be used to get the include directories. This is because the includes for these packages might be split across multiple directories, depending on how they have been installed.

The POSITION\_INDEPENDENT\_CODE property is necessary for static libraries that might eventually be linked with other code into a shared object (.so, .dylib, .dll). In this case, consumers of the static library will be linking it into a Python extension module.

Originally the enable\_testing() was placed in tests/CMakeLists.txt, but this meant that developers had to cd into the "tests" folder before running ctest.  The usual convention is to put enable\_testing() in the main CMakeLists.txt.